### PR TITLE
update chokidar, loosen semver ranges, release 1.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2021 Instructure, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions.
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha"
   },
-  "repository": "instructure/brandable_css",
+  "repository": "https://github.com/instructure/brandable_css",
   "author": [
     "Ryan Shaw <ryankshaw@gmail.com>",
     "Ahmad Amireh <ahmad@instructure.com>"
@@ -19,22 +19,22 @@
     "src"
   ],
   "dependencies": {
-    "autoprefixer": "^7.0.0",
-    "chalk": "^2.1.0",
-    "chokidar": "^1.6.1",
-    "commander": "^2.9.0",
-    "debug": "^3.1.0",
-    "fs-extra-promise": "^1.0.1",
-    "glob": "^7.1.1",
-    "js-yaml": "^3.8.2",
-    "lodash": "^4.17.4",
-    "node-sass": "^4.5.0",
-    "postcss": "^6.0.1",
-    "postcss-url": "^7.1.2",
-    "rev-hash": "^2.0.0"
+    "autoprefixer": "^7",
+    "chalk": "^2",
+    "chokidar": "^3",
+    "commander": "^2",
+    "debug": "^3",
+    "fs-extra-promise": "^1",
+    "glob": "^7",
+    "js-yaml": "^3",
+    "lodash": "^4",
+    "node-sass": "~4.14.1",
+    "postcss": "^6",
+    "postcss-url": "^7",
+    "rev-hash": "^2"
   },
   "devDependencies": {
-    "chai": "^4.3.4",
-    "mocha": "^9.0.2"
+    "chai": "^4",
+    "mocha": "^9"
   }
 }


### PR DESCRIPTION
npm audit reports only node-sass to contain vulnerabilities but we don't
care since we're moving to dart-sass