### PR TITLE
generate size-efficient index files

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -11,8 +11,7 @@ let cache = {
   }
 }
 
-function initCache (name) {
-  const filename = CONFIG.paths[name]
+function initCache ({ filename }) {
   let self = {
     isSaved: false,
 
@@ -31,19 +30,23 @@ function initCache (name) {
       return value
     },
 
-    save () {
+    save (opts = {}) {
       debug('saving', self.isSaved, filename)
       if (self.isSaved) return
       self.isSaved = true
-      return outputJsonAsync(filename, self.data, {spaces: 2})
+      return outputJsonAsync(filename, self.data, {spaces: opts.compact ? 0 : 2})
     },
 
     clearMatching (query) {
       self.data = _.omit(self.data, (v, key) => key.match(query))
     }
   }
-  cache[name] = self
+  return self
 }
-caches.forEach(initCache)
+
+caches.forEach(name => {
+  cache[name] = initCache({ filename: CONFIG.paths[name] })
+})
 
 module.exports = cache
+module.exports.createCache = initCache

--- a/src/contriveId.js
+++ b/src/contriveId.js
@@ -1,0 +1,3 @@
+const revHash = require('rev-hash')
+
+module.exports = (string, size) => revHash(string).slice(0, size)

--- a/src/generateIndex.js
+++ b/src/generateIndex.js
@@ -1,0 +1,75 @@
+const minimatch = require('minimatch')
+const contriveId = require('./contriveId')
+const indexOrValue = (index, value) => index === -1 ? value : index
+
+module.exports = ({ name, pattern, combinedChecksums, keysz, manifestKeySeperator }) => {
+  const variants = []
+  const reserved = {}
+
+  const checksums = Object.keys(combinedChecksums).filter(key => minimatch(key, pattern)).reduce((acc, bundleAndVariant) => {
+    const data = combinedChecksums[bundleAndVariant]
+
+    // keys look like this:
+    //
+    //     jst/courses/Syllabus.scss$$$$$$$$$$$responsive_layout_high_contrast
+    //     ^^^^^^^^^^^^^^^^^^^^                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    //     bundle                              variant
+    //
+    const [bundle, variant] = bundleAndVariant.split(manifestKeySeperator);
+
+    // since there are very few jst/ bundles, we can save some bytes by using
+    // some deterministic id instead of their full bundle names, in this case
+    // it's the first few characters of the md5
+    //
+    // webpack has to stay in sync with this! see frontend_build/i18nLinerHandlebars.js#buildCssReference
+    const id = contriveId(bundle.replace(/\.s[ca]ss$/, ''), keysz)
+
+    if (reserved.hasOwnProperty(id) && reserved[id] !== bundle) {
+      throw new Error(
+        `index(${name}): bundle "${bundle}" collides with "${reserved[id]}" at ` +
+        `id "${id}". Consider increasing the id_size of the index or renaming ` +
+        `one of the source files.`
+      )
+    }
+
+    reserved[id] = bundle
+
+    // when brandable_css reports "includesNoVariables" for a bundle, there
+    // will be only one file regardless of the variant, so again we save some
+    // space by using a 1 element array
+    if (data.includesNoVariables === true) {
+      acc[id] = [data.combinedChecksum]
+    }
+    else {
+      // keep track of the variants as we encounter them, for templates that
+      // do use variables (and thus will have one file per variant), the
+      // checksum for a specific variant file will be found in its set at
+      // the index of that variant in the "variants" set
+      //
+      //     variants = ["normal", "high_contrast", "responsive_high_contrast"]
+      //     checksums["fd0"][1] = "aaaa"
+      //
+      // "aaaa" is the checksum of the file for the variant "high_contrast"
+      //
+      if (!variants.includes(variant)) {
+        variants.push(variant)
+      }
+
+      acc[id] = acc[id] || []
+      acc[id][variants.indexOf(variant)] = (
+        // save more space by replacing duplicate checksums with references
+        // to the first (by its index)
+        //
+        //    checksums["fd0"] = ['asdf', 'asdf', 'asdf', 'baab']
+        //    # into =>
+        //    checksums["fd0"] = ['asdf', 0, 0, 'baab']
+        //
+        indexOrValue(acc[id].indexOf(data.combinedChecksum), data.combinedChecksum)
+      )
+    }
+
+    return acc
+  }, {})
+
+  return [variants, checksums]
+}

--- a/test/generateIndex.test.js
+++ b/test/generateIndex.test.js
@@ -1,0 +1,131 @@
+const subject = require('../src/generateIndex')
+const { assert } = require('chai')
+const contriveId = require('../src/contriveId')
+
+describe('generateIndex', () => {
+  it("processes only the bundles that start with jst/", () => {
+    const [variants, checksums] = subject({
+      pattern: 'jst/**',
+      combinedChecksums: {
+        "bundles/account_admin_tools.scss$$$$$$$$$$$new_styles_high_contrast": {
+          "combinedChecksum": "f11ca29695",
+          "includesNoVariables": false
+        },
+        "jst/courses/Syllabus.scss$$$$$$$$$$$responsive_layout_normal_contrast": {
+          "combinedChecksum": "39352b56d7",
+          "includesNoVariables": false
+        }
+      }
+    })
+
+    assert.equal(Object.keys(checksums).length, 1)
+  })
+
+  it("assigns a contrived id to a template", () => {
+    const [variants, checksums] = subject({
+      pattern: 'jst/**',
+      manifestKeySeperator: '$$$$$$$$$$$',
+      combinedChecksums: {
+        "jst/courses/Syllabus.scss$$$$$$$$$$$responsive_layout_normal_contrast": {
+          "combinedChecksum": "39352b56d7",
+          "includesNoVariables": false
+        }
+      }
+    })
+
+    assert.deepEqual(Object.keys(checksums), [contriveId('jst/courses/Syllabus')])
+  })
+
+  it("tracks the variants it sees", () => {
+    const [variants, checksums] = subject({
+      pattern: '**',
+      manifestKeySeperator: '$$$$$$$$$$$',
+      combinedChecksums: {
+        "jst/courses/Syllabus.scss$$$$$$$$$$$first": {
+          "combinedChecksum": "39352b56d7",
+          "includesNoVariables": false
+        },
+        "jst/courses/Syllabus.scss$$$$$$$$$$$second": {
+          "combinedChecksum": "39352b56d7",
+          "includesNoVariables": false
+        },
+        "jst/courses/Syllabus.scss$$$$$$$$$$$third": {
+          "combinedChecksum": "39352b56d7",
+          "includesNoVariables": false
+        },
+      }
+    })
+
+    assert.deepEqual(variants, [ 'first', 'second', 'third' ])
+  })
+
+  it("uses a numeric index instead of the checksum if it's been seen before", () => {
+    const [variants, checksums] = subject({
+      pattern: '**',
+      manifestKeySeperator: '$$$$$$$$$$$',
+      combinedChecksums: {
+        "jst/courses/Syllabus.scss$$$$$$$$$$$first": {
+          "combinedChecksum": "xxx",
+          "includesNoVariables": false
+        },
+        "jst/courses/Syllabus.scss$$$$$$$$$$$second": {
+          "combinedChecksum": "xxx",
+          "includesNoVariables": false
+        },
+        "jst/courses/Syllabus.scss$$$$$$$$$$$third": {
+          "combinedChecksum": "yyy",
+          "includesNoVariables": false
+        },
+        "jst/courses/Syllabus.scss$$$$$$$$$$$fourth": {
+          "combinedChecksum": "yyy",
+          "includesNoVariables": false
+        },
+      }
+    })
+
+    const id = contriveId('jst/courses/Syllabus')
+
+    assert.deepEqual(checksums[id], ['xxx', 0, 'yyy', 2])
+  })
+
+  it("includes only one checksum for templates that use no variables", () => {
+    const [variants, checksums] = subject({
+      pattern: '**',
+      manifestKeySeperator: '$$$$$$$$$$$',
+      combinedChecksums: {
+        "jst/courses/Syllabus.scss$$$$$$$$$$$first": {
+          "combinedChecksum": "xxx",
+          "includesNoVariables": true
+        },
+        "jst/courses/Syllabus.scss$$$$$$$$$$$second": {
+          "combinedChecksum": "xxx",
+          "includesNoVariables": true
+        }
+      }
+    })
+
+    const id = contriveId('jst/courses/Syllabus')
+
+    assert.deepEqual(checksums[id], ['xxx'])
+  })
+
+  it("bails if it finds a collision", () => {
+    assert.throws(() => {
+      subject({
+        pattern: '**',
+        manifestKeySeperator: '$$$$$$$$$$$',
+        keysz: 1,
+        combinedChecksums: {
+          "bah$$$$$$$$$$$first": {
+            "combinedChecksum": "xxx",
+            "includesNoVariables": true
+          },
+          "gz$$$$$$$$$$$first": {
+            "combinedChecksum": "xxx",
+            "includesNoVariables": true
+          }
+        }
+      })
+    }, 'bundle "gz" collides with "bah" at id "c"')
+  })
+})


### PR DESCRIPTION
this index allows us to inline the data needed to load stylesheets for
handlebars templates at runtime instead of how we're doing it today
where we hard-code the mapping of variant -> checksum for each template
at build time

the index is tuned for this purpose, right now on Canvas the handlebars
index is ~1.6kB which is not bad (Rails will inline it)

the reason I opted to do it here and not in Ruby land is because the
javascript test suite also needs this information, not just Rails.. so
it's more universal this way: when we ask brandable_css to generate the
files and manifest, it also generates the indices. It's simpler to think
about