### PR TITLE
stop appending SASS_STYLE to output filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ paths:
 
 ## Changelog
 
+### 2.0.0
+
+- SASS_STYLE environment variable is no longer appended to filenames, so where
+  by configuring `bundles_with_deps: ./a.json` you used to get either
+  `a.jsonnested` or `a.jsoncompressed` based on what SASS_STYLE indicated, you
+  now unconditionally get `a.json`
+- RAILS_ENV environment variable no longer controls SASS_STYLE in its absence;
+  SASS_STYLE now defaults to "nested", so in a production environment where
+  you want compressed output, be sure to specify `SASS_STYLE=compressed` when
+  running brandable_css
+
 ### 1.0.0
 
 - Re-released under `@instructure/brandable-css`

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,7 +1,6 @@
 const debug = require('debug')('brandable_css:cache')
 const _ = require('lodash')
 const CONFIG = require('./config')
-const SASS_STYLE = require('./sass_style')
 const {readJsonSync, outputJsonAsync} = require('fs-extra-promise')
 
 const caches = ['file_checksums', 'bundles_with_deps']
@@ -13,7 +12,7 @@ let cache = {
 }
 
 function initCache (name) {
-  const filename = CONFIG.paths[name] + SASS_STYLE
+  const filename = CONFIG.paths[name]
   let self = {
     isSaved: false,
 

--- a/src/sass_style.js
+++ b/src/sass_style.js
@@ -1,7 +1,6 @@
 // If you want compressed output (eg: in production), set the environment
 // variable SASS_STYLE=compressed. For rails apps, we'll fall back to a sane
 // default of using "compressed" if RAILS_ENV == production
-const SASS_STYLE = process.env.SASS_STYLE ||
-                   (process.env.RAILS_ENV === 'production' ? 'compressed' : 'nested')
+const SASS_STYLE = process.env.SASS_STYLE || 'nested'
 
 module.exports = SASS_STYLE

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -22,7 +22,7 @@ describe('brandable_css', () => {
   it('generates the manifest', async () => {
     const manifest = JSON.parse(
       fsX.readFileSync(
-        path.resolve(dist, 'bundles_with_deps.jsonnested'),
+        path.resolve(dist, 'bundles_with_deps.json'),
         'utf8'
       )
     )


### PR DESCRIPTION
the variable extension name of output files has been causing a lot of
headache in the various builds and environments that Canvas uses
brandable_css in, this patch normalizes it so that it always outputs
using the filenames provided in the configuration

this is a breaking change, see release notes in README