### PR TITLE
Fix the crazy icon canvas dev bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/brandable_css",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "This is what we use to compile sass in canvas-lms with all our variants and custom theme editor css",
   "main": "./src/main.js",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -67,7 +67,7 @@ async function findChangedBundles (bundles) {
         for (let filename of cached.includedFiles) {
           if (fasterHasFileChanged(filename)) {
             thisVariantHasChanged = true
-            break
+            // Don't break to ensure that we refresh the cached hash for any changed files
           }
         }
 

--- a/src/main.js
+++ b/src/main.js
@@ -67,7 +67,7 @@ async function findChangedBundles (bundles) {
         for (let filename of cached.includedFiles) {
           // Don't exit early if a file has changed to ensure
           // we refresh the cached hash for *all* changed files
-          thisVariantHasChanged ||= fasterRefreshHashIfFileChanged(filename)
+          thisVariantHasChanged = thisVariantHasChanged || fasterRefreshHashIfFileChanged(filename)
         }
 
         // check to actually make sure the css file exists

--- a/src/main.js
+++ b/src/main.js
@@ -67,7 +67,8 @@ async function findChangedBundles (bundles) {
         for (let filename of cached.includedFiles) {
           // Don't exit early if a file has changed to ensure
           // we refresh the cached hash for *all* changed files
-          thisVariantHasChanged = thisVariantHasChanged || fasterRefreshHashIfFileChanged(filename)
+          const hasFileChanged = fasterRefreshHashIfFileChanged(filename)
+          thisVariantHasChanged = thisVariantHasChanged || hasFileChanged
         }
 
         // check to actually make sure the css file exists


### PR DESCRIPTION
Previously, brandable_css could output css with `url` references replaced to reference stale rev hashes if multiple input files to a bundle had changed.  In Canvas this lead to icon soup, though it also could potentially cause other "fun".  It also meant that it would take N runs for brandable_css to stop regenerating a file, where N = the number of simultaneously changed dependencies.

This pr fixes that by always refreshing all the hashes.