### PR TITLE
silence sass deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/brandable_css",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "This is what we use to compile sass in canvas-lms with all our variants and custom theme editor css",
   "main": "./src/main.js",
   "scripts": {

--- a/src/compileBundle.js
+++ b/src/compileBundle.js
@@ -60,7 +60,8 @@ module.exports = async function compileBundle ({bundleName, variant}) {
     includePaths: includePaths,
     outputStyle: SASS_STYLE === 'nested' ? 'expanded' : SASS_STYLE,
     sourceComments: SASS_STYLE !== 'compressed',
-    sourceMap: false
+    sourceMap: false,
+    silenceDeprecations: ['import', 'global-builtin', 'color-functions', 'legacy-js-api', 'if-function']
   })
 
   const postcssResult = await postcss([


### PR DESCRIPTION
     1	## Summary
     2	
     3	Silence known Dart Sass deprecation warnings that are emitted during Canvas asset compilation by adding the `silenceDeprecations` option to the `sass.renderSync()` call in `compileBundle.js`.
     4	
     5	The suppressed deprecations are:
     6	- **import** - Canvas still uses legacy `@import` syntax
     7	- **global-builtin** - Canvas uses global built-in Sass functions
     8	- **color-functions** - Legacy color function usage
     9	- **legacy-js-api** - The legacy JavaScript API for Dart Sass
    10	- **if-function** - The `if()` function deprecation
    11	
    12	These warnings are expected and produce significant noise during compilation since Canvas has not yet migrated away from these legacy patterns. The sass package was upgraded to 1.98.0 in commit c329672, which introduced these deprecation warnings.
    13	
    14	## Test plan
    15	- Run `yarn run compile-sass` and verify deprecation warnings are no longer emitted
    16	- Verify compiled CSS output is unchanged
    17	